### PR TITLE
feat:add additional route support to client vpn module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ module "client_vpn" {
 
   # Network associations
   subnet_ids = var.client_vpn_config.subnet_ids
+  routes     = var.client_vpn_config.routes
 
   tags = var.tags
 }

--- a/modules/client-vpn/main.tf
+++ b/modules/client-vpn/main.tf
@@ -136,3 +136,23 @@ resource "aws_ec2_client_vpn_authorization_rule" "this" {
   access_group_id        = each.value.access_group_id
   authorize_all_groups   = each.value.authorize_all_groups
 }
+
+resource "aws_ec2_client_vpn_route" "this" {
+  for_each = {
+    for pair in flatten([
+      for route in var.routes : [
+        for subnet_id in var.subnet_ids : {
+          destination_cidr_block = route.destination_cidr_block
+          subnet_id              = subnet_id
+        }
+      ]
+    ]) :
+    "${pair.destination_cidr_block}-${pair.subnet_id}" => pair
+  }
+
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.this.id
+  destination_cidr_block = each.value.destination_cidr_block
+  target_vpc_subnet_id   = each.value.subnet_id
+
+  depends_on = [aws_ec2_client_vpn_network_association.this]
+}

--- a/modules/client-vpn/variables.tf
+++ b/modules/client-vpn/variables.tf
@@ -181,6 +181,14 @@ variable "subnet_ids" {
   description = "The ID of the subnets to associate with the Client VPN endpoint."
 }
 
+variable "routes" {
+  type = list(object({
+    destination_cidr_block = string
+  }))
+  description = "Additional Client VPN routes to create for each associated subnet."
+  default     = []
+}
+
 variable "client_cidr_block" {
   type        = string
   description = "Client CICR block"

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,11 @@ variable "client_vpn_config" {
 
     subnet_ids = list(string)
 
+    # additional client vpn routes
+    routes = optional(list(object({
+      destination_cidr_block = string
+    })), [])
+
     # authorization options
     authorization_options = map(object({
       target_network_cidr  = string
@@ -132,6 +137,7 @@ variable "client_vpn_config" {
     authentication_options = null
     authorization_options  = null
     client_cidr_block      = null
+    routes                 = []
     subnet_ids             = []
   }
 }


### PR DESCRIPTION
Adds support for additional Client VPN routes in the ARC VPN module.

## Changes

- adds `client_vpn_config.routes`
- wires routes into `modules/client-vpn`
- creates `aws_ec2_client_vpn_route` resources for each route/subnet combination

